### PR TITLE
Implement haptics

### DIFF
--- a/Example/stork-controller.xcodeproj/project.pbxproj
+++ b/Example/stork-controller.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		89ADD549225DF02300A27FE6 /* SPStorkHapticMoments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89ADD548225DF02300A27FE6 /* SPStorkHapticMoments.swift */; };
 		F40DB702222A9202004E1CCB /* SPStorkViewControllerExtenshion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40DB6FB222A9202004E1CCB /* SPStorkViewControllerExtenshion.swift */; };
 		F40DB703222A9202004E1CCB /* SPStorkTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40DB6FC222A9202004E1CCB /* SPStorkTransitioningDelegate.swift */; };
 		F40DB704222A9202004E1CCB /* SPStorkPresentingAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40DB6FD222A9202004E1CCB /* SPStorkPresentingAnimationController.swift */; };
@@ -141,6 +142,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		89ADD548225DF02300A27FE6 /* SPStorkHapticMoments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPStorkHapticMoments.swift; sourceTree = "<group>"; };
 		F40DB6FB222A9202004E1CCB /* SPStorkViewControllerExtenshion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPStorkViewControllerExtenshion.swift; sourceTree = "<group>"; };
 		F40DB6FC222A9202004E1CCB /* SPStorkTransitioningDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPStorkTransitioningDelegate.swift; sourceTree = "<group>"; };
 		F40DB6FD222A9202004E1CCB /* SPStorkPresentingAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPStorkPresentingAnimationController.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 				F40DB6FF222A9202004E1CCB /* SPStorkController.swift */,
 				F40DB700222A9202004E1CCB /* SPStorkIndicatorView.swift */,
 				F40DB701222A9202004E1CCB /* SPStorkDismissingAnimationController.swift */,
+				89ADD548225DF02300A27FE6 /* SPStorkHapticMoments.swift */,
 			);
 			path = SPStorkController;
 			sourceTree = "<group>";
@@ -900,6 +903,7 @@
 				F455273F221C009E00F40446 /* SPButton.swift in Sources */,
 				F4552759221C009E00F40446 /* SPTableController.swift in Sources */,
 				F4552786221C009E00F40446 /* SPLayout.swift in Sources */,
+				89ADD549225DF02300A27FE6 /* SPStorkHapticMoments.swift in Sources */,
 				F40DB708222A9202004E1CCB /* SPStorkDismissingAnimationController.swift in Sources */,
 				F455279E221C009E00F40446 /* SPShare.swift in Sources */,
 				F40DB703222A9202004E1CCB /* SPStorkTransitioningDelegate.swift in Sources */,

--- a/Example/stork-controller/Controller.swift
+++ b/Example/stork-controller/Controller.swift
@@ -28,6 +28,7 @@ class Controller: UIViewController {
     @objc func presentModalViewController() {
         let modal = ModalViewController()
         let transitionDelegate = SPStorkTransitioningDelegate()
+        transitionDelegate.hapticMoments = [.whilstPresenting, .whilstDismissing]
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         self.present(modal, animated: true, completion: nil)
@@ -36,6 +37,7 @@ class Controller: UIViewController {
     @objc func presentModalTableViewController() {
         let modal = ModalTableViewController()
         let transitionDelegate = SPStorkTransitioningDelegate()
+        transitionDelegate.hapticMoments = [.afterPresenting, .afterDismissing]
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         self.present(modal, animated: true, completion: nil)

--- a/Example/stork-controller/Frameworks/SPStorkController/SPStorkHapticMoments.swift
+++ b/Example/stork-controller/Frameworks/SPStorkController/SPStorkHapticMoments.swift
@@ -1,0 +1,17 @@
+//
+//  SPStorkHapticMoments.swift
+//  stork-controller
+//
+//  Created by Sjoerd Janssen on 10/04/2019.
+//  Copyright © 2019 Ivan Vorobei. All rights reserved.
+//
+
+import UIKit
+
+public enum SPStorkHapticMoments {
+    case whilstPresenting
+    case afterPresenting
+    case whilstDismissing
+    case afterDismissing
+    case none
+}

--- a/Example/stork-controller/Frameworks/SPStorkController/SPStorkTransitioningDelegate.swift
+++ b/Example/stork-controller/Frameworks/SPStorkController/SPStorkTransitioningDelegate.swift
@@ -30,6 +30,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
     public var customHeight: CGFloat? = nil
     public var translateForDismiss: CGFloat = 200
     public var cornerRadius: CGFloat = 10
+    public var hapticMoments: [SPStorkHapticMoments] = [.whilstPresenting, .whilstDismissing]
     
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         let controller = SPStorkPresentationController(presentedViewController: presented, presenting: presenting)
@@ -41,6 +42,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
         controller.translateForDismiss = self.translateForDismiss
         controller.cornerRadius = self.cornerRadius
         controller.transitioningDelegate = self
+        controller.hapticMoments = self.hapticMoments
         return controller
     }
     


### PR DESCRIPTION
This PR aims to implement haptics into the library. You can set haptics with the `hapticMoments` property of `transitioningDelegate`.

There's support for 4 (actually 5) haptic moments. `whilstPresenting`, `afterPresenting`, `whilstDismissing` and `afterDismissing`. The fifth one is `none`, just because I think it looks better than passing an empty array.

You can see an example below.

    @objc func presentModalViewController() {
        let modal = ModalViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.whilstPresenting, .whilstDismissing]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }
    
    @objc func presentModalTableViewController() {
        let modal = ModalTableViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.afterPresenting, .afterDismissing]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }

    @objc func presentModaSecondViewController() {
        let modal = ADifferentViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.none]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }