### PR TITLE
Implement haptic support 

### DIFF
--- a/Source/SPStorkController/Enums/SPStorkHapticMoments.swift
+++ b/Source/SPStorkController/Enums/SPStorkHapticMoments.swift
@@ -1,0 +1,17 @@
+//
+//  SPStorkHapticMoments.swift
+//  stork-controller
+//
+//  Created by Sjoerd Janssen on 10/04/2019.
+//  Copyright © 2019 Ivan Vorobei. All rights reserved.
+//
+
+import UIKit
+
+public enum SPStorkHapticMoments {
+	case whilstPresenting
+	case afterPresenting
+	case whilstDismissing
+	case afterDismissing
+	case none
+}

--- a/Source/SPStorkController/TransitioningDelegate/SPStorkPresentationController.swift
+++ b/Source/SPStorkController/TransitioningDelegate/SPStorkPresentationController.swift
@@ -38,6 +38,8 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
     var pan: UIPanGestureRecognizer?
     var tap: UITapGestureRecognizer?
     
+    var hapticMoments: [SPStorkHapticMoments] = []
+    
     private var closeButton = SPStorkCloseButton()
     private var indicatorView = SPStorkIndicatorView()
     private var gradeView: UIView = UIView()
@@ -59,6 +61,12 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
     
     private let alpha: CGFloat =  0.51
     var cornerRadius: CGFloat = 10
+    
+    private lazy var feedbackGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        generator.prepare()
+        return generator
+    }()
     
     private var scaleForPresentingView: CGFloat {
         guard let containerView = containerView else { return 0 }
@@ -164,6 +172,10 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
                 guard let `self` = self else { return }
                 self.snapshotView?.transform = transformForSnapshotView
                 self.gradeView.alpha = self.alpha
+                
+                if self.hapticMoments.contains(.whilstPresenting) {
+                    self.feedbackGenerator.impactOccurred()
+                }
             }, completion: { _ in
                 self.snapshotView?.transform = .identity
                 rootSnapshotView?.removeFromSuperview()
@@ -172,6 +184,10 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
     }
     
     override func presentationTransitionDidEnd(_ completed: Bool) {
+        if hapticMoments.contains(.afterPresenting) {
+            self.feedbackGenerator.impactOccurred()
+        }
+        
         super.presentationTransitionDidEnd(completed)
         guard let containerView = containerView else { return }
         self.updateSnapshot()
@@ -260,6 +276,10 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
                 self.snapshotView?.transform = .identity
                 self.snapshotViewContainer.transform = finalTransform
                 self.gradeView.alpha = 0
+                
+                if self.hapticMoments.contains(.whilstDismissing) {
+                    self.feedbackGenerator.impactOccurred()
+                }
             }, completion: { _ in
                 rootSnapshotView?.removeFromSuperview()
                 rootSnapshotRoundedView?.removeFromSuperview()
@@ -267,6 +287,10 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
     }
     
     override func dismissalTransitionDidEnd(_ completed: Bool) {
+        if self.hapticMoments.contains(.afterDismissing) {
+            self.feedbackGenerator.impactOccurred()
+        }
+        
         super.dismissalTransitionDidEnd(completed)
         guard let containerView = containerView else { return }
         

--- a/Source/SPStorkController/TransitioningDelegate/SPStorkTransitioningDelegate.swift
+++ b/Source/SPStorkController/TransitioningDelegate/SPStorkTransitioningDelegate.swift
@@ -32,6 +32,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
     public var customHeight: CGFloat? = nil
     public var translateForDismiss: CGFloat = 200
     public var cornerRadius: CGFloat = 10
+    public var hapticMoments: [SPStorkHapticMoments] = [.whilstPresenting, .whilstDismissing]
     public weak var storkDelegate: SPStorkControllerDelegate? = nil
     
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
@@ -46,6 +47,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
         controller.translateForDismiss = self.translateForDismiss
         controller.cornerRadius = self.cornerRadius
         controller.transitioningDelegate = self
+        controller.hapticMoments = self.hapticMoments
         controller.storkDelegate = self.storkDelegate
         return controller
     }


### PR DESCRIPTION
This PR aims to implement haptics into the library. You can set haptics with the `hapticMoments` property of `transitioningDelegate`.

There's support for 4 (actually 5) haptic moments. `whilstPresenting`, `afterPresenting`, `whilstDismissing` and `afterDismissing`. The fifth one is `none`, just because I think it looks better than passing an empty array.

You can see an example below.

    @objc func presentModalViewController() {
        let modal = ModalViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.whilstPresenting, .whilstDismissing]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }
    
    @objc func presentModalTableViewController() {
        let modal = ModalTableViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.afterPresenting, .afterDismissing]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }

    @objc func presentModaSecondViewController() {
        let modal = ADifferentViewController()
        let transitionDelegate = SPStorkTransitioningDelegate()
        transitionDelegate.hapticMoments = [.none]
        modal.transitioningDelegate = transitionDelegate
        modal.modalPresentationStyle = .custom
        self.present(modal, animated: true, completion: nil)
    }