### PR TITLE
Made the demo project support iPad and silenced two warnings with Xcode 12.5 and Swift 5.4

### DIFF
--- a/Example/stork-controller.xcodeproj/project.pbxproj
+++ b/Example/stork-controller.xcodeproj/project.pbxproj
@@ -1255,7 +1255,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "by.ivanvorobei.stork-controller";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1274,7 +1274,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "by.ivanvorobei.stork-controller";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Example/stork-controller/Frameworks/SPStorkController/Protocols/SPStorkControllerConfirmDelegate.swift
+++ b/Example/stork-controller/Frameworks/SPStorkController/Protocols/SPStorkControllerConfirmDelegate.swift
@@ -21,7 +21,7 @@
 
 import UIKit
 
-@objc public protocol SPStorkControllerConfirmDelegate: class {
+@objc public protocol SPStorkControllerConfirmDelegate: AnyObject {
     
     var needConfirm: Bool { get }
     

--- a/Example/stork-controller/Frameworks/SPStorkController/Protocols/SPStorkControllerDelegate.swift
+++ b/Example/stork-controller/Frameworks/SPStorkController/Protocols/SPStorkControllerDelegate.swift
@@ -21,7 +21,7 @@
 
 import UIKit
 
-@objc public protocol SPStorkControllerDelegate: class {
+@objc public protocol SPStorkControllerDelegate: AnyObject {
     
     @objc optional func didDismissStorkBySwipe()
     

--- a/Example/stork-controller/ModalTableViewController.swift
+++ b/Example/stork-controller/ModalTableViewController.swift
@@ -86,7 +86,11 @@ extension ModalTableViewController: SPStorkControllerConfirmDelegate {
     }
     
     func confirm(_ completion: @escaping (Bool) -> ()) {
-        let alertController = UIAlertController(title: "Need dismiss?", message: "It test confirm option for SPStorkController", preferredStyle: .actionSheet)
+        var style: UIAlertController.Style = .actionSheet
+        if UIDevice.current.userInterfaceIdiom != .phone {
+            style = .alert
+        }
+        let alertController = UIAlertController(title: "Need dismiss?", message: "It test confirm option for SPStorkController", preferredStyle: style)
         alertController.addDestructiveAction(title: "Confirm", complection: {
             completion(true)
         })

--- a/Example/stork-controller/ModalViewController.swift
+++ b/Example/stork-controller/ModalViewController.swift
@@ -39,7 +39,11 @@ extension ModalViewController: SPStorkControllerConfirmDelegate {
     }
     
     func confirm(_ completion: @escaping (Bool) -> ()) {
-        let alertController = UIAlertController(title: "Need dismiss?", message: "It test confirm option for SPStorkController", preferredStyle: .actionSheet)
+        var style: UIAlertController.Style = .actionSheet
+        if UIDevice.current.userInterfaceIdiom != .phone {
+            style = .alert
+        }
+        let alertController = UIAlertController(title: "Need dismiss?", message: "It test confirm option for SPStorkController", preferredStyle: style)
         alertController.addDestructiveAction(title: "Confirm", complection: {
             completion(true)
         })


### PR DESCRIPTION
Here comes a crash on iPad and two warnings with Xcode 12.5 and Swift 5.4.
This PR fixes these.

- Crash
  - The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'
- Warnings
  - Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead